### PR TITLE
[ZP-8706] Support Cordova 11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@zenput/cordova-plugin-pushwoosh-intercom",
-  "version": "21.11.18-H12M40S43",
+  "version": "22.3.5-H13M15S44",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zenput/cordova-plugin-pushwoosh-intercom",
-  "version": "21.11.18-H12M40S43",
+  "version": "22.3.5-H13M15S44",
   "description": "Adds support for Intercom push notifications to an Android Cordova app that relies on Pushwoosh for push notifications",
   "main": "index.js",
   "scripts": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="@zenput/cordova-plugin-pushwoosh-intercom" version="21.11.18-H12M40S43">
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="@zenput/cordova-plugin-pushwoosh-intercom" version="22.3.5-H13M15S44">
     <name>@zenput/cordova-plugin-pushwoosh-intercom</name>
     <description>
         Adds support for Intercom push notifications to an Android Cordova app that relies on Pushwoosh for push notifications.

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="cordova-plugin-pushwoosh-intercom" version="21.11.18-H12M40S43">
-    <name>cordova-plugin-pushwoosh-intercom</name>
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="@zenput/cordova-plugin-pushwoosh-intercom" version="21.11.18-H12M40S43">
+    <name>@zenput/cordova-plugin-pushwoosh-intercom</name>
     <description>
         Adds support for Intercom push notifications to an Android Cordova app that relies on Pushwoosh for push notifications.
     </description>


### PR DESCRIPTION
This update brings support for Cordova 11 by using the `@zenput/` scoping everywhere.