### PR TITLE
[ZP-10484] Add `android:exported=false` to <service>

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -10,7 +10,7 @@
         <!-- <dependency id="pushwoosh-cordova-plugin" version="^7.17.0" /> -->
         <!-- <dependency id="cordova-plugin-intercom" version="^6.2.0" /> -->
         <config-file target="AndroidManifest.xml" parent="/manifest/application">
-            <service android:name="com.zenput.push.FirebaseMessagingRouterService" android:stopWithTask="false">
+            <service android:name="com.zenput.push.FirebaseMessagingRouterService" android:stopWithTask="false" android:exported="false">
                 <intent-filter>
                     <action android:name="com.google.firebase.MESSAGING_EVENT"/>
                 </intent-filter>


### PR DESCRIPTION
This is a required change for `cordova-android@11`. [See here](https://developer.android.com/about/versions/12/behavior-changes-12#exported) for details about this requirement.